### PR TITLE
Added Commands to make running the project easier

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,5 +7,5 @@ cd ios
 pod install
 cd ..
 
-react-native run-ios
+yarn ios
 ```

--- a/package.json
+++ b/package.json
@@ -4,10 +4,11 @@
   "private": true,
   "scripts": {
     "android": "react-native run-android",
-    "ios": "react-native run-ios",
+    "ios": "react-native run-ios --simulator='iPhone 11'",
     "start": "react-native start",
     "test": "jest",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "clean-ios": "rm -rf ./node_modules && rm -rf ./ios/build && rm -rf ~/Library/Developer/Xcode/DerivedData && yarn"
   },
   "dependencies": {
     "react": "16.9.0",


### PR DESCRIPTION
- yarn ios will now use the iPhone 11 Simulator instead of the default which might have been iPhone X which is not installed by default in newer versions of XCode
- yarn clean-ios will clean out node modules, podfiles and derived data to get a fresh start if there are any caching issues